### PR TITLE
修复 Linux 构建时第三方插件编译错误

### DIFF
--- a/linux/CMakeLists.txt
+++ b/linux/CMakeLists.txt
@@ -42,6 +42,13 @@ endif()
 function(APPLY_STANDARD_SETTINGS TARGET)
   target_compile_features(${TARGET} PUBLIC cxx_std_14)
   target_compile_options(${TARGET} PRIVATE -Wall -Werror)
+
+  # 豁免第三方插件编译警告：tray_manager 的 deprecated API、hotkey_manager_linux 的未初始化变量
+  target_compile_options(${TARGET} PRIVATE
+    -Wno-error=deprecated-declarations
+    -Wno-error=sometimes-uninitialized
+  )
+
   target_compile_options(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:-O3>")
   target_compile_definitions(${TARGET} PRIVATE "$<$<NOT:$<CONFIG:Debug>>:NDEBUG>")
 endfunction()


### PR DESCRIPTION
**问题描述：**

在 Linux 平台上执行 `flutter build linux` 时，由于 GCC 将警告视为错误（`-Werror`），导致第三方插件编译失败。
极有可能是我使用的Linux发行版（manjaro）的GCC默认配置比较严格导致的。

```
/home/r/tmp/ClipShare/linux/flutter/ephemeral/.plugin_symlinks/tray_manager/linux/tray_manager_plugin.cc:118:17: error: 'app_indicator_new' is deprecated [-Werror,-Wdeprecated-declarations]
/home/r/tmp/ClipShare/linux/flutter/ephemeral/.plugin_symlinks/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc:41:7: error: variable 'identifier' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
/home/r/tmp/ClipShare/linux/flutter/ephemeral/.plugin_symlinks/hotkey_manager_linux/linux/hotkey_manager_linux_plugin.cc:112:7: error: variable 'keystring' is used uninitialized whenever 'if' condition is false [-Werror,-Wsometimes-uninitialized]
Building Linux application...
Build process failed
xdg-open: file '../build/linux/x64/release/bundle' does not exist
```

附上我的系统环境：

```
gcc (GCC) 15.2.1 20251112
 gcc -v
使用内建 specs。
COLLECT_GCC=gcc
COLLECT_LTO_WRAPPER=/usr/lib/gcc/x86_64-pc-linux-gnu/15.2.1/lto-wrapper
目标：x86_64-pc-linux-gnu
配置为：/build/gcc/src/gcc/configure --enable-languages=ada,c,c++,d,fortran,go,lto,m2,objc,obj-c++,rust,cobol --enable-bootstrap --prefix=/usr --libdir=/usr/lib --libexecdir=/usr/lib --mandir=/usr/share/man --infodir=/usr/share/info --with-bugurl=https://gitlab.archlinux.org/archlinux/packaging/packages/gcc/-/issues --with-build-config=bootstrap-lto --with-linker-hash-style=gnu --with-system-zlib --enable-__cxa_atexit --enable-cet=auto --enable-checking=release --enable-clocale=gnu --enable-default-pie --enable-default-ssp --enable-gnu-indirect-function --enable-gnu-unique-object --enable-libstdcxx-backtrace --enable-link-serialization=1 --enable-linker-build-id --enable-lto --enable-multilib --enable-plugin --enable-shared --enable-threads=posix --disable-libssp --disable-libstdcxx-pch --disable-werror
线程模型：posix
支持的 LTO 压缩算法：zlib zstd
gcc 版本 15.2.1 20251112 (GCC)

OS: Manjaro Linux x86_64
Kernel: Linux 6.6.119-1-MANJARO
Packages: 2316 (pacman)[stable], 7 (flatpak-user), 7 (snap)
Shell: zsh 5.9
WM: i3 4.25 (X11)
Cursor: xcursor-breeze-snow
Terminal: alacritty 0.16.1
Terminal Font: monospace (10.5pt, Regular)
CPU: AMD Ryzen 9 5900X (24) @ 4.95 GHz
GPU: NVIDIA GeForce GTX 1050 [Discrete]Locale: zh_CN.UTF-8
Flutter 3.38.1 • channel  • https://github.com/flutter/flutter.git
Framework • revision archlinuxaur (unknown (arch linux aur package)) • 2038-01-19 03:14:08
Engine • revision b5990e5ccc5e (unknown (arch linux aur package))
Tools • Dart 3.10.1 • DevTools 2.51.1
```

**解决方案**：

在 linux/CMakeLists.txt 中为特定编译警告添加豁免选项，
解决 tray_manager 和 hotkey_manager_linux 插件因 GCC 将警告 视为错误而导致的构建失败问题。


