### PR TITLE
Fix device connection queue completion and add arbitration diagnostics

### DIFF
--- a/lib/app/services/transport/socket_service.dart
+++ b/lib/app/services/transport/socket_service.dart
@@ -440,6 +440,7 @@ class SocketService extends GetxService with ScreenOpenedObserver, DataSender {
   Future<void> _runDeviceConnectTask() async {
     await for (final event in _deviceConnectionQueue.stream) {
       final completer = event.completer;
+      var success = false;
       try {
         final endPoint = event.endPoint;
         final socket = event.socket;
@@ -476,9 +477,13 @@ class SocketService extends GetxService with ScreenOpenedObserver, DataSender {
         if(identical(client, newClient)) {
           await _onClientConnected(client);
         }
+        success = true;
       } catch (err, stack) {
-        completer?.complete(false);
         Log.error(tag, "error:$err, event:$event", stack);
+      } finally {
+        if (completer != null && !completer.isCompleted) {
+          completer.complete(success);
+        }
       }
     }
   }
@@ -503,6 +508,7 @@ class SocketService extends GetxService with ScreenOpenedObserver, DataSender {
     final oldSkt = _devSockets[devId];
     //没旧连接，直接用
     if (oldSkt == null) {
+      Log.debug(tag, "connection selected(new): devId=$devId reason=no_old isSender=$isSender");
       _devSockets[devId] = newSkt;
       return newSkt;
     }
@@ -515,6 +521,7 @@ class SocketService extends GetxService with ScreenOpenedObserver, DataSender {
 
     //旧连接死了，直接替换
     if (!oldValid) {
+      Log.debug(tag, "connection selected(new): devId=$devId reason=old_offline isSender=$isSender");
       await oldSkt.sendData(MsgType.disConnect, {});
       await oldSkt.close(true);
       _devSockets[devId] = newSkt;
@@ -523,6 +530,10 @@ class SocketService extends GetxService with ScreenOpenedObserver, DataSender {
 
     //两个都活着 → 裁决
     final keepNew = _shouldKeepNew(isSender, devId);
+    Log.debug(
+      tag,
+      "connection arbitration: devId=$devId isSender=$isSender keepNew=$keepNew old=${oldSkt.hashCode} new=${newSkt.hashCode}",
+    );
 
     if (keepNew) {
       await oldSkt.sendData(MsgType.disConnect, {});


### PR DESCRIPTION
### Motivation
- Events pushed to `_deviceConnectionQueue` sometimes include a `Completer` that was not completed on success, causing callers waiting on those completers (e.g. discovery/reconnect flows) to hang or timeout. 
- Simultaneous peer-to-peer connections (A→B and B→A) need clearer runtime diagnostics to validate the current tie-break logic and understand why both sides might choose different sockets. 
- Preserve the existing serial processing and arbitration approach while making success/failure observable and deterministic for callers.

### Description
- Ensure every `_deviceConnectionQueue` event completes its optional `Completer` in a `finally` block, and return `true` for successful connection/arbitration by setting a `success` flag. 
- Set `success = true` on successful connection/handling so callers receive positive completion instead of timing out. 
- Add targeted `Log.debug` statements in `_handleNewConnection` to record why a new connection was selected (`no_old`, `old_offline`) and to log arbitration results (`keepNew`, old/new socket hashes) for post-mortem diagnosis. 
- Changes are limited to `lib/app/services/transport/socket_service.dart` and keep the existing serial + arbitration logic intact.

### Testing
- Performed a code diff/inspection of the updated `lib/app/services/transport/socket_service.dart` to verify the changes and placements of `completer` completion and new logs. 
- Attempted to run the project formatter with `dart format lib/app/services/transport/socket_service.dart` and `flutter format lib/app/services/transport/socket_service.dart`, but both CLIs are unavailable in this environment so formatting could not be executed. 
- No automated unit or integration tests were executed in this environment; changes were limited to deterministic control-flow and logging modifications to aid runtime debugging and should be safe for further CI/test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f075172430832da23b9662c2784979)