### PR TITLE
build-linux CI: add Linux dev packages, run updatedb/ldconfig, and improve artifact discovery

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,10 +25,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
         sudo apt-get install -y locate rpm patchelf
-        sudo apt-get install -y libayatana-appindicator3-dev
-        sudo apt-get install -y libkeybinder-3.0-dev
+        sudo apt-get install -y libayatana-appindicator3-dev libayatana-indicator3-dev
+        sudo apt-get install -y libkeybinder-3.0-dev libdbusmenu-glib-dev libdbusmenu-gtk3-dev
+        sudo apt-get install -y libxtst-dev libwayland-dev wayland-protocols
+        sudo apt-get install -y libx11-dev libxext-dev
         sudo apt-get install -y fuse libfuse-dev
         sudo apt-get install -y wget
+        sudo updatedb || true
+        sudo ldconfig
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -62,6 +66,7 @@ jobs:
         find dist -name "*.deb" -exec cp {} output/ \;
         find dist -name "*.AppImage" -exec cp {} output/ \;
         find dist -name "*.rpm" -exec cp {} output/ \;
+        find dist -maxdepth 4 -type f | sort
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
### Motivation
- Ensure the CI runner has additional development libraries required to build and package the Linux desktop artifacts (indicators, DBus menu, X11/Wayland, and input test libs).
- Ensure linker cache and file database are current to avoid missing runtime/linker or file lookup issues during packaging.
- Improve artifact discovery so all generated package files under `dist` are visible to the upload step.

### Description
- Install additional apt packages: `libayatana-indicator3-dev`, `libdbusmenu-glib-dev`, `libdbusmenu-gtk3-dev`, `libxtst-dev`, `libwayland-dev`, `wayland-protocols`, `libx11-dev`, and `libxext-dev` alongside existing deps.
- Run `sudo updatedb || true` and `sudo ldconfig` after package installation to refresh the file database and linker cache.
- Simplify some `apt-get install` lines by combining related packages on single lines.
- Add a final `find dist -maxdepth 4 -type f | sort` invocation in the build step to list discovered artifacts before upload.

### Testing
- No automated tests were executed as part of this workflow-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c1ac0e44832d87b2cfbf2e535c35)