### PR TITLE
linux: add build deps, avoid bundling Wayland core libs, and adjust packaging steps

### DIFF
--- a/.github/workflows/build-linux.yml
+++ b/.github/workflows/build-linux.yml
@@ -25,10 +25,14 @@ jobs:
         sudo apt-get update
         sudo apt-get install -y clang cmake ninja-build pkg-config libgtk-3-dev liblzma-dev
         sudo apt-get install -y locate rpm patchelf
-        sudo apt-get install -y libayatana-appindicator3-dev
-        sudo apt-get install -y libkeybinder-3.0-dev
+        sudo apt-get install -y libayatana-appindicator3-dev libayatana-indicator3-dev
+        sudo apt-get install -y libkeybinder-3.0-dev libdbusmenu-glib-dev libdbusmenu-gtk3-dev
+        sudo apt-get install -y libxtst-dev libwayland-dev wayland-protocols
+        sudo apt-get install -y libx11-dev libxext-dev
         sudo apt-get install -y fuse libfuse-dev
         sudo apt-get install -y wget
+        sudo updatedb || true
+        sudo ldconfig
 
     - name: Setup Flutter
       uses: subosito/flutter-action@v2
@@ -62,6 +66,7 @@ jobs:
         find dist -name "*.deb" -exec cp {} output/ \;
         find dist -name "*.AppImage" -exec cp {} output/ \;
         find dist -name "*.rpm" -exec cp {} output/ \;
+        find dist -maxdepth 4 -type f | sort
 
     - name: Upload artifacts
       uses: actions/upload-artifact@v4

--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -34,6 +34,8 @@ keywords:
 # 以下示例展示了如何将 libcurl 库与您的应用捆绑在一起
 #
 include:
+  # Do not bundle wayland core libs (e.g. libwayland-client).
+  # They are tightly coupled with host graphics stack and may break GL context creation on Wayland.
   - libkeybinder-3.0.so.0
   - libayatana-appindicator3.so.1
   - libayatana-indicator3.so.7
@@ -41,4 +43,3 @@ include:
   - libdbusmenu-glib.so.4
   - libdbusmenu-gtk3.so.4
   - libXtst.so.6
-  - libwayland-client.so.0

--- a/scripts/build_linux.sh
+++ b/scripts/build_linux.sh
@@ -21,7 +21,6 @@ APPIMAGE_RUNTIME_LIBS=(
     "libdbusmenu-glib.so.4"
     "libdbusmenu-gtk3.so.4"
     "libXtst.so.6"
-    "libwayland-client.so.0"
 )
 
 find_shared_library() {


### PR DESCRIPTION
### Motivation

- Ensure the Linux CI has all required development packages for packaging and AppImage creation and avoid bundling Wayland core libraries that can break GL on Wayland hosts.

### Description

- Added additional APT packages in `.github/workflows/build-linux.yml`, including `libayatana-indicator3-dev`, `libdbusmenu-glib-dev`, `libdbusmenu-gtk3-dev`, `libxtst-dev`, `libwayland-dev`, `wayland-protocols`, `libx11-dev`, and `libxext-dev`, and added `updatedb` and `ldconfig` steps.
- Added a `find dist -maxdepth 4 -type f | sort` listing step to the `Build & Package with Fastforge` job to surface produced artifacts.
- Removed `libwayland-client.so.0` from the AppImage bundle list in `linux/packaging/appimage/make_config.yaml` and added a comment explaining that Wayland core libs should not be bundled.
- Removed `libwayland-client.so.0` from the `APPIMAGE_RUNTIME_LIBS` array in `scripts/build_linux.sh` so the runtime bundle no longer includes Wayland core libs.

### Testing

- Executed the Linux packaging workflow `build-linux` on CI which completed and uploaded artifacts successfully.
- Ran the packaging script `./scripts/build_linux.sh pack` locally to verify bundling changes and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12c1ac0e44832d87b2cfbf2e535c35)