### PR TITLE
fix(appimage): avoid bundling unstable runtime libs in FastForge AppImage

### DIFF
--- a/linux/packaging/appimage/make_config.yaml
+++ b/linux/packaging/appimage/make_config.yaml
@@ -41,4 +41,12 @@ include:
   - libdbusmenu-glib.so.4
   - libdbusmenu-gtk3.so.4
   - libXtst.so.6
-  - libwayland-client.so.0
+
+# 避免打包基础系统/图形栈库：这些库在不同发行版 ABI 差异较大，
+# 在 Arch 上可能导致 GTK/GL 上下文初始化失败（如 gdk_gl_context_make_current 断言）。
+exclude:
+  - libstdc++.so.6
+  - libgcc_s.so.1
+  - libSM.so.6
+  - libICE.so.6
+  - libuuid.so.1


### PR DESCRIPTION
### Motivation
- FastForge packaging was forcing inclusion of distro-sensitive graphics/runtime libraries which can produce ABI mismatches across distributions and trigger Flutter/GTK GL initialization errors such as `gdk_gl_context_make_current` failing. 
- The local AppImage layout uses a different library loading location and did not bundle those problematic host-runtime libs, explaining the differing runtime behavior on Arch Linux.

### Description
- Removed `libwayland-client.so.0` from the forced `include` list in `linux/packaging/appimage/make_config.yaml`.
- Added an `exclude` list to prevent bundling base/runtime libraries that should come from the target system, specifically `libstdc++.so.6`, `libgcc_s.so.1`, `libSM.so.6`, `libICE.so.6`, and `libuuid.so.1`.
- Added a comment explaining that excluding these libraries reduces cross-distro ABI conflicts and lowers the chance of GTK/GL context initialization failures on Arch.

### Testing
- Verified repository AppImage artifacts with `rg --files appimage` and confirmed differences between FastForge and local AppImage layouts using `find ... | comm -3`, which succeeded. 
- Inspected build and packaging scripts with `sed -n '1,240p' appimage/build_linux.sh` and `sed -n '1,260p' linux/packaging/appimage/make_config.yaml`, which succeeded. 
- Printed and compared `AppRun` from both `appimage/github-action` and `appimage/local-build` with `sed -n`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f4be65cc832d8ee785015b58ba75)