### PR TITLE
fix: resolve multi-window Win+V popup and paste reliability issues

### DIFF
--- a/lib/app/handlers/hot_key_handler.dart
+++ b/lib/app/handlers/hot_key_handler.dart
@@ -64,7 +64,7 @@ class AppHotKeyHandler {
         }
         //只允许弹窗一次
         final windowId = appConfig.historyWindow?.windowId;
-        final isHide = true && multiWindowService.isHideWindow(windowId);
+        final isHide = multiWindowService.isHideWindow(windowId);
         if (ids.contains(windowId) && !isHide) {
           await multiWindowService.closeWindow(windowId!, windowId, MultiWindowTag.history);
           //偏好为使用相同快捷键关闭，直接结束
@@ -92,11 +92,19 @@ class AppHotKeyHandler {
         //限制在屏幕范围内
         final [x, y] = [min(maxX, offset.dx), min(maxY, offset.dy)];
         if (appConfig.historyWindow != null) {
-          await multiWindowService.showWindowFromHide(
-            appConfig.historyWindow!.windowId,
-            position: [x, y],
-          );
-          return;
+          try {
+            await multiWindowService.showWindowFromHide(
+              appConfig.historyWindow!.windowId,
+              position: [x, y],
+            );
+          } catch (e) {
+            // IPC 失败说明子窗口可能已不可用，重置引用以便下次重新创建窗口。
+            logger.warn(tag, "showWindowFromHide failed, will recreate: $e");
+            appConfig.historyWindow = null;
+          }
+          if (appConfig.historyWindow != null) {
+            return;
+          }
         }
         //createWindow里面的参数必须传
         final title = TranslationKey.historyRecord.tr;

--- a/lib/app/modules/splash_module/splash_controller.dart
+++ b/lib/app/modules/splash_module/splash_controller.dart
@@ -287,13 +287,20 @@ class SplashController extends GetxController {
           return jsonEncode(sourceService.appInfos);
         case MultiWindowMethod.copy:
           final id = args["id"];
-          dbService.historyDao.getById(id).then(
-            (history) async {
-              if (history == null) return;
+          try {
+            // 等待复制并粘贴完成后再返回，确保弹窗在粘贴完成之前不会提前隐藏，
+            // 避免粘贴目标窗口错乱。
+            final history = await dbService.historyDao.getById(id);
+            if (history != null) {
               await history.copyContent();
-              clipboardManager.pasteToPreviousWindow();
-            },
-          );
+              await clipboardManager.pasteToPreviousWindow();
+            }
+          } catch (err, stack) {
+            // 复制/粘贴失败不能让 IPC 中断：否则子窗口 await copy 抛错，
+            // onCopied 不执行、弹窗不会关闭。记录日志后正常返回，
+            // 让子窗口照常走关闭流程。
+            logger.error(tag, err, stack);
+          }
           break;
         case MultiWindowMethod.copyContent:
           final content = args["content"];

--- a/lib/app/modules/views/windows/history/history_window.dart
+++ b/lib/app/modules/views/windows/history/history_window.dart
@@ -72,6 +72,10 @@ class _HistoryWindowState extends State<HistoryWindow> with WindowListener, Wind
   final windowControlService = Get.find<WindowControlService>();
   Timer? _timer;
   bool filterLoading = true;
+  /// 弹窗最近一次从隐藏状态恢复显示的时间，用于抑制显示瞬间的失焦自动关闭。
+  DateTime? _lastShownAt;
+  /// 本次显示后是否已成功获得焦点；成功聚焦前的失焦视为显示/抢焦过程的瞬时事件。
+  bool _focusedAfterShow = false;
   late final HistoryFilterController historyFilterController;
 
   @override
@@ -126,15 +130,22 @@ class _HistoryWindowState extends State<HistoryWindow> with WindowListener, Wind
       case MultiWindowMethod.notify:
         refresh();
         break;
-      //关闭（隐藏）窗口
+      //从隐藏状态恢复显示弹窗
       case MultiWindowMethod.showWindowFromHide:
         var position = args["position"];
         if (position != null) {
           var [x, y] = (position as List<dynamic>).cast<double>();
           windowManager.setPosition(Offset(x, y));
         }
+        // 记录显示时间：显示/抢焦过程中可能产生瞬时失焦事件，
+        // 需要抑制这段时间内的失焦自动关闭，避免窗口“闪一下就消失”。
+        _lastShownAt = DateTime.now();
+        _focusedAfterShow = false;
         widget.windowController.show();
         windowManager.setAlwaysOnTop(true);
+        // 显示后主动抢占焦点，确保原生前台窗口追踪器记录“当前软件→弹窗”的切换，
+        // 使 pasteToPreviousWindow 的“上一个窗口”始终为打开弹窗前所在的软件。
+        windowManager.focus();
         historyFilterController.resetFilter();
         refresh();
         break;
@@ -171,11 +182,24 @@ class _HistoryWindowState extends State<HistoryWindow> with WindowListener, Wind
   @override
   /// 子窗口失焦时按主窗口偏好决定是否自动隐藏，保持多窗口状态由主窗口统一管理。
   void onWindowBlur() {
+    // 弹窗刚显示、尚未成功抢到焦点前的失焦是显示/置顶过程的瞬时事件，
+    // 不触发自动关闭，避免“闪一下就消失”、需按两次 Win+V 的问题。
+    // 一旦成功聚焦（onWindowFocus），后续任何失焦都视为真实失焦，立即生效。
+    final shownAt = _lastShownAt;
+    if (shownAt != null && DateTime.now().difference(shownAt) < 500.ms && !_focusedAfterShow) {
+      return;
+    }
     if (!multiWindowConfigService.autoClosePopupOnBlur) {
       return;
     }
     // 统一走主窗口维护的隐藏流程，避免子窗口自行关闭后主窗口状态不同步。
     multiWindowService.closeWindow(0, widget.windowController.windowId, MultiWindowTag.history);
+  }
+
+  @override
+  void onWindowFocus() {
+    // 窗口成功获得焦点后，失焦即视为真实失焦，不再被瞬时事件抑制。
+    _focusedAfterShow = true;
   }
 
   @override

--- a/lib/app/services/channels/multi_window_channel.dart
+++ b/lib/app/services/channels/multi_window_channel.dart
@@ -44,9 +44,15 @@ class MultiWindowChannelService extends GetxService {
     int targetWindowId,
     int closeWindowId,
     MultiWindowTag tag,
-  ) {
+  ) async {
     if (!PlatformExt.isDesktop) return Future.value();
-    windowManager.hide();
+    try {
+      // windowManager.hide() 是 async 方法，必须 await 才能真正捕获其异常；
+      // 未 await 的 Future error 不会被同步 try-catch 捕获，会变成 unhandled async error。
+      await windowManager.hide();
+    } catch (_) {
+      // 子窗口中 windowManager.hide() 可能失败，但状态同步不能因此中断。
+    }
     _hideWindowIds.add(closeWindowId);
     return DesktopMultiWindow.invokeMethod(
       targetWindowId,

--- a/lib/app/services/tray_service.dart
+++ b/lib/app/services/tray_service.dart
@@ -11,7 +11,6 @@ import 'package:clipshare/app/utils/constants.dart';
 import 'package:clipshare/app/utils/extensions/keyboard_key_extension.dart';
 import 'package:clipshare/app/utils/extensions/number_extension.dart';
 import 'package:clipshare/app/utils/log.dart';
-import 'package:flutter/services.dart';
 import 'package:get/get.dart';
 import 'package:tray_manager/tray_manager.dart';
 
@@ -19,6 +18,10 @@ import 'window_service.dart';
 
 class TrayService extends GetxService with TrayListener, DevAliveListener {
   bool _trayClick = false;
+  // 托盘闪烁进行中标志：闪烁期间忽略新的闪烁请求，避免并发 setIcon("") 竞态
+  // 导致托盘图标最终停留在被清空的状态（fork 版 tray_manager 对空路径
+  // LoadImage 失败会 NIM_MODIFY 空图标，把图标从任务栏移除）。
+  bool _flashing = false;
   static const tag = "TrayService";
   final windowService = Get.find<WindowService>();
   final appConfig = Get.find<ConfigService>();
@@ -141,24 +144,34 @@ class TrayService extends GetxService with TrayListener, DevAliveListener {
     intervalDuration ??= const Duration(milliseconds: 300);
     totalDuration ??= const Duration(seconds: 5);
 
-    final endTime = DateTime.now().add(totalDuration);
-    DateTime now;
-    if (toolTip != null) {
-      await _updateDevAliveTooltip(toolTip);
+    if (_flashing) {
+      return;
     }
-    do {
+    _flashing = true;
+    try {
+      final endTime = DateTime.now().add(totalDuration);
+      DateTime now;
+      if (toolTip != null) {
+        await _updateDevAliveTooltip(toolTip);
+      }
+      do {
+        await trayManager.setIcon("");
+        await Future.delayed(intervalDuration);
+
+        await trayManager.setIcon(iconAssetPath);
+        await Future.delayed(intervalDuration);
+
+        now = DateTime.now();
+      } while (now.isBefore(endTime));
+    } finally {
+      // 无论闪烁是否异常中断，都必须恢复托盘图标，否则 setIcon("") 会
+      // 把图标清空并停留在消失状态（任务栏找不到图标）。
+      _flashing = false;
       await trayManager.setIcon("");
       await Future.delayed(intervalDuration);
-
-      await trayManager.setIcon(iconAssetPath);
-      await Future.delayed(intervalDuration);
-
-      now = DateTime.now();
-    } while (now.isBefore(endTime));
-    await trayManager.setIcon("");
-    await Future.delayed(intervalDuration);
-    await _resetIcon();
-    await _updateDevAliveTooltip(Constants.appName);
+      await _resetIcon();
+      await _updateDevAliveTooltip(Constants.appName);
+    }
   }
 
   Future<void> flashTrayWarning([String? toolTip]) async {


### PR DESCRIPTION
## 背景

修复多窗口弹窗（Win+V）的两个概率性 bug，以及实测过程中发现的附加问题：

1. 双击复制剪贴条目后，再次按 Win+V 有概率无法唤起面板；
2. 双击复制完成后，光标位置粘贴动作有概率失败（目标窗口错乱）；
3. 实测发现：开启「弹窗自动关闭」后点击外部有 500ms 空窗、托盘图标在闪烁后可能消失。

## 改动清单（5 个文件，+89 / -31）

| 文件 | 改动 |
|------|------|
| `splash_controller.dart` | `MultiWindowMethod.copy` 由 fire-and-forget 改为完整 await 链，粘贴完成后弹窗才隐藏（消除目标错乱竞态）；外层加 try-catch，失败不让 IPC 中断（弹窗照常关闭） |
| `history_window.dart` | 弹窗显示时 `focus()` 抢占焦点，让原生前台窗口追踪器正确记录"上一个窗口"（粘贴目标）；新增 `_lastShownAt` + `_focusedAfterShow`，仅在"显示后 500ms 内且尚未聚焦"时抑制瞬时失焦，聚焦后点击外部立即关闭 |
| `hot_key_handler.dart` | `showWindowFromHide` IPC 失败时重置窗口引用并自动重建，消除"一次失败永远失败"；清理冗余 `true &&` |
| `multi_window_channel.dart` | `closeWindow` 的 `windowManager.hide()` 改为 `await` 并捕获异常，状态同步不被异步异常中断 |
| `tray_service.dart` | `flashTray` 增加并发标志 + `try-finally`，闪烁异常中断时也能恢复托盘图标 |

## 行为变化说明

- 弹窗显示时会抢焦点（`focus()`）——这是保证粘贴目标正确的必要手段；副作用是输入框光标短暂消失、部分应用（如抖音网页评论、微信）粘贴时选区丢失变成"末尾追加"。**已知取舍**，根治方案（弹窗不抢焦点 + 原生记录粘贴目标）计划在后续 PR 实施。
- `closeOnSameHotKey` 行为保持不变（窗口可见时再按 Win+V 关闭）。

## 已知遗留（计划后续 PR）

1. **Win11 记事本等 UWP 应用完全不能粘贴**：原生 `pasteToPreviousWindow` 用 `SendMessage(WM_KEYDOWN)` 模拟 Ctrl+V，UWP/TSF 输入系统不处理该消息。计划改用 `SendInput`。
2. **弹窗抢焦点导致的选区丢失**：计划"弹窗不抢焦点 + 原生 `storeCurrentWindowHwnd()` + 前台变化事件"方案根治。

## 验证

- Windows 10/11 Release 构建实测：按住 Win+V 唤起、双击复制粘贴到 Notepad/浏览器/QQ、点击外部关闭、连续循环 5 次均正常；托盘图标闪烁后正常恢复。
