### PR TITLE
Feat/search history

### DIFF
--- a/lib/app/handlers/hot_key_handler.dart
+++ b/lib/app/handlers/hot_key_handler.dart
@@ -65,12 +65,16 @@ class AppHotKeyHandler {
         //只允许弹窗一次
         final windowId = appConfig.historyWindow?.windowId;
         final isHide = multiWindowService.isHideWindow(windowId);
+        bool isRelocate = false;
         if (ids.contains(windowId) && !isHide) {
-          await multiWindowService.closeWindow(windowId!, windowId, MultiWindowTag.history);
-          //偏好为使用相同快捷键关闭，直接结束
+          //偏好为使用相同快捷键关闭
           if (appConfig.closeOnSameHotKey) {
+            await multiWindowService.closeWindow(windowId!, windowId, MultiWindowTag.history);
             return;
           }
+          // 偏好为不关闭：不 hide 弹窗，直接重新定位到光标处（下方 showWindowFromHide 会 setPosition）。
+          // 避免隐藏 active 弹窗触发前台窗口变化，被 onForegroundChanged 误判为切走而关闭（闪一下消失）。
+          isRelocate = true;
         }
         var posCfg = appConfig.historyDialogPosition;
         var radio = windowManager.getDevicePixelRatio();
@@ -96,6 +100,7 @@ class AppHotKeyHandler {
             await multiWindowService.showWindowFromHide(
               appConfig.historyWindow!.windowId,
               position: [x, y],
+              isRelocate: isRelocate,
             );
           } catch (e) {
             // IPC 失败说明子窗口可能已不可用，重置引用以便下次重新创建窗口。

--- a/lib/app/modules/views/windows/history/history_window.dart
+++ b/lib/app/modules/views/windows/history/history_window.dart
@@ -141,9 +141,12 @@ class _HistoryWindowState extends State<HistoryWindow> with WindowListener, Wind
         widget.windowController.show();
         windowManager.setAlwaysOnTop(true);
         // 不再调用 windowManager.focus()：弹窗已通过 WS_EX_NOACTIVATE 设为不激活，
-        // 避免抢占前台焦点打断用户输入；粘贴目标由插件记录的“打开弹窗前的前台窗口”保证。
-        historyFilterController.resetFilter();
-        refresh();
+        // 避免抢占前台焦点打断用户输入
+        // 重新定位
+        if (args["isRelocate"] != true) {
+          historyFilterController.resetFilter();
+          refresh();
+        }
         break;
       //关闭（隐藏）窗口
       case MultiWindowMethod.closeWindow:

--- a/lib/app/services/channels/multi_window_channel.dart
+++ b/lib/app/services/channels/multi_window_channel.dart
@@ -23,10 +23,12 @@ class MultiWindowChannelService extends GetxService {
     int targetWindowId, {
     List<double>? position,
     Map<String, dynamic>? args,
+    bool isRelocate = false,
   }) {
     if (!PlatformExt.isDesktop) return Future.value();
     Map<String, dynamic> data = {
       "position": position,
+      "isRelocate": isRelocate,
     };
     if (args != null) {
       data["args"] = args;

--- a/lib/app/widgets/filter/history_filter.dart
+++ b/lib/app/widgets/filter/history_filter.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:clipshare/app/data/enums/history_content_type.dart';
 import 'package:clipshare/app/data/enums/translation_key.dart';
 import 'package:clipshare/app/data/models/search_filter.dart';
@@ -8,9 +10,9 @@ import 'package:clipshare/app/theme/app_theme.dart';
 import 'package:clipshare/app/widgets/filter/filter_detail.dart';
 import 'package:clipshare/app/widgets/filter/filter_type_segmented.dart';
 import 'package:flutter/material.dart';
-import 'package:get/get.dart';
-
 import 'package:flutter_material_design_icons/flutter_material_design_icons.dart';
+import 'package:get/get.dart';
+import 'package:window_manager/window_manager.dart';
 
 class HistoryFilterController {
   final allDevices = <Device>[].obs;
@@ -25,6 +27,8 @@ class HistoryFilterController {
   final focusNode = FocusNode();
   final TextEditingController textController = TextEditingController();
   final loading = false.obs;
+  /// 实时搜索防抖：输入停止 200ms 后才触发查询，避免每键一次 IPC/列表重建
+  Timer? _searchDebounce;
 
   SearchFilter get filter => SearchFilter(
     content: content.value,
@@ -78,8 +82,18 @@ class HistoryFilterController {
   }
 
   void dispose() {
+    _searchDebounce?.cancel();
     focusNode.dispose();
     textController.dispose();
+  }
+
+  ///实时搜索：输入变化时更新过滤条件，停止输入 200ms 后触发查询
+  void onTextChanged(String value) {
+    _searchDebounce?.cancel();
+    _searchDebounce = Timer(const Duration(milliseconds: 200), () {
+      content.value = value;
+      onSearchBtnClicked();
+    });
   }
 
   void setAllDevices(List<Device> devices) {
@@ -168,6 +182,13 @@ class HistoryFilterSearchRow extends StatelessWidget {
                 controller: controller.textController,
                 focusNode: controller.focusNode,
                 autofocus: false,
+                onTap: () {
+                  // 弹窗 WS_EX_NOACTIVATE 不激活、收不到键盘输入（搜索框无法打字）。
+                  // 用户点击搜索框 = 明确要输入，此处激活弹窗使其可输入；
+                  // 代价：搜索期间原应用（如微信）失焦、选区被清——主动搜索场景可接受。
+                  windowManager.focus();
+                },
+                onChanged: controller.onTextChanged,
                 textAlignVertical: TextAlignVertical.center,
                 decoration: noneBorderInputDecoration.copyWith(
                   fillColor: showFillColor ? null : Colors.transparent,

--- a/lib/app/widgets/filter/history_filter.dart
+++ b/lib/app/widgets/filter/history_filter.dart
@@ -27,7 +27,7 @@ class HistoryFilterController {
   final focusNode = FocusNode();
   final TextEditingController textController = TextEditingController();
   final loading = false.obs;
-  /// 实时搜索防抖：输入停止 200ms 后才触发查询，避免每键一次 IPC/列表重建
+  /// 实时搜索防抖
   Timer? _searchDebounce;
 
   SearchFilter get filter => SearchFilter(
@@ -111,6 +111,7 @@ class HistoryFilterController {
   void resetFilter({SearchFilter? filter}) {
     filter ??= SearchFilter();
     content.value = filter.content;
+    textController.text = filter.content;
     startDate.value = filter.startDate;
     endDate.value = filter.endDate;
     selectedTags.addAll(filter.tags);
@@ -183,9 +184,7 @@ class HistoryFilterSearchRow extends StatelessWidget {
                 focusNode: controller.focusNode,
                 autofocus: false,
                 onTap: () {
-                  // 弹窗 WS_EX_NOACTIVATE 不激活、收不到键盘输入（搜索框无法打字）。
-                  // 用户点击搜索框 = 明确要输入，此处激活弹窗使其可输入；
-                  // 代价：搜索期间原应用（如微信）失焦、选区被清——主动搜索场景可接受。
+                  // 弹窗 WS_EX_NOACTIVATE 不激活、收不到键盘输入（搜索框无法打字）
                   windowManager.focus();
                 },
                 onChanged: controller.onTextChanged,


### PR DESCRIPTION
# feat: 修复搜索框输入、弹窗闪烁与搜索词残留，支持实时搜索，新增历史记录全选

## 概述

Win+V 剪贴板历史弹窗内的搜索框**无法输入文字**（中文/英文都不行）。本 PR 修复该问题，并顺带：① 把搜索升级为**实时过滤**（边输入边搜，200ms 防抖）；② 历史记录（主窗口 + Win+V 弹窗）的多选模式新增**全选/取消全选**；③ 修复搜索框**关闭重开后搜索词残留**、**光标在搜索栏按 Win+V 弹窗闪一下消失**两个衍生 bug。

改动 6 个文件：`history_filter.dart`（搜索组件，弹窗与主窗口共用）、`clip_multi_selection_controller.dart`、`clip_list_fab.dart`、`history_window.dart`、`hot_key_handler.dart`、`multi_window_channel.dart`。

## 一、搜索框输入修复

### 根因

弹窗带 `WS_EX_NOACTIVATE`（不激活、不抢焦点，保护用户正在输入的输入框选区）。Windows 只向**已激活（active）窗口**投递键盘消息——弹窗永不激活，搜索框永远收不到按键。原有 `requestFocus()` 只能设置 Flutter 内部焦点，无法让窗口收到系统键盘事件。这是 `WS_EX_NOACTIVATE` 与"弹窗内搜索框"设计矛盾的固有缺陷。

### 改动

点击搜索框时激活弹窗（用户点击 = 明确输入意图）：

```dart
onTap: () {
  // 弹窗 WS_EX_NOACTIVATE 不激活、收不到键盘输入（搜索框无法打字）。
  // 用户点击搜索框 = 明确要输入，此处激活弹窗使其可输入；
  // 代价：搜索期间原应用（如微信）失焦、选区被清——主动搜索场景可接受。
  windowManager.focus();
},
```

- 不用 `autofocus`（弹窗显示时就抢焦点，无预期地清选区，违背 NOACTIVATE 设计）；
- **只激活搜索框场景**——点条目粘贴仍不激活，弹窗 NOACTIVATE 行为与点击外部关闭链路不受影响。

**权衡**：Windows 平台不存在"不激活窗口还能完整输入中文"的通道（IME 需要焦点窗口上下文，系统 Win+V 面板是系统 UI 特权）。搜索期间原应用短暂失焦（微信选区被清）——搜索是主动操作，此代价可接受。

## 二、实时搜索（200ms 防抖）

```dart
///实时搜索：输入变化时更新过滤条件，停止输入 200ms 后触发查询
void onTextChanged(String value) {
  _searchDebounce?.cancel();
  _searchDebounce = Timer(const Duration(milliseconds: 200), () {
    content.value = value;
    onSearchBtnClicked();
  });
}
```

- `onChanged` 边输入边过滤，清空自动恢复全量列表；
- **200ms 防抖**：每次查询走 IPC + 列表重建，防抖避免每键刷屏；
- `dispose()` 补 `_searchDebounce?.cancel()` 防泄漏；
- 保留"回车搜索"与放大镜按钮（兼容旧交互）。

## 三、多选模式新增全选/取消全选

复用项目其他模块（`sync_file`/`rules`）已有的全选切换模式（`TranslationKey.selectAll`/`cancelSelectAll` 已存在）。

### 控制器

```dart
/// 全选/取消全选：全部已选中则清除，否则全选
void toggleSelectAll(List<ClipData> items) {
  if (!_enabled) return;
  if (_selectedItems.length == items.length) {
    _selectedItems.clear();
  } else {
    _selectedItems.addAll(items);   // LinkedHashSet 保序，合并复制顺序不受影响
  }
}
```

### 入口（主窗口 + 弹窗一致）

两处多选 FAB 的 actions 开头新增"全选"按钮（`Icons.select_all`，tooltip 随选中状态在"全选/取消全选"间切换）：

- 主窗口历史页：`clip_list_fab.dart`（`toggleSelectAll(widget.list)` + `_refreshState()`）
- Win+V 弹窗：`history_window.dart`（`toggleSelectAll(_list)` + `_refreshState()`）；弹窗 FAB 展开半径 70→110 避免按钮拥挤

## 四、修复搜索词关闭重开未清除

### 根因

弹窗关闭（hide）后重开走 `showWindowFromHide`，其内部 `historyFilterController.resetFilter()` 只重置过滤状态 `content.value`，**没有重置搜索框的 `TextEditingController.text`**——关闭重开后搜索框仍显示上次关键词（实际过滤已回全量，UI 与状态不一致）。

### 改动

`resetFilter` 补一行同步搜索框文本：

```dart
void resetFilter({SearchFilter? filter}) {
  filter ??= SearchFilter();
  content.value = filter.content;
  textController.text = filter.content;   // 新增：清空搜索框显示文本
  startDate.value = filter.startDate;
  ...
}
```

### 行为

关闭弹窗 → 下次打开：搜索框清空（与过滤状态一致）。

## 五、修复光标在搜索栏按 Win+V 弹窗闪一下消失

### 根因

方案一（点搜索框 `windowManager.focus()`）使弹窗成为 Windows 前台（active）窗口。当"相同快捷键关闭"关闭（`closeOnSameHotKey=false`）时，按 Win+V 走 `closeWindow`（隐藏）→ `showWindowFromHide`（重显）的切换；**隐藏一个 active 弹窗会触发 Windows 前台窗口变化**，被原生插件 `onForegroundChanged(isSelf=false)` 捕获，若"失焦自动关闭"开启则误判"用户切走"再次隐藏弹窗，与重显竞争 → 弹窗闪一下消失。

### 改动

`closeOnSameHotKey=false` 时不再隐藏弹窗，改为**直接重新定位**（`showWindowFromHide` 的 `setPosition` 移动窗口），从源头消除"隐藏 active 弹窗"这个触发点：

- `hot_key_handler.dart`：`closeOnSameHotKey=false` 不调 `closeWindow`，标记 `isRelocate=true` 后走 `showWindowFromHide(isRelocate: true)`；
- `multi_window_channel.dart`：`showWindowFromHide` 增加 `bool isRelocate=false`，经 IPC 透传给子窗口；
- `history_window.dart`：`isRelocate=true` 时只 `setPosition`，跳过 `resetFilter()`/`refresh()`——**重新定位保留搜索词**（仅移动位置，不视为重开）。

### 行为

光标在搜索栏按 Win+V：弹窗**重新定位，不闪不消失**，搜索词保留。

## 行为变化

| 场景            | 之前         | 现在                   |
| ------------- | ---------- | -------------------- |
| 点击搜索框         | 无法输入文字     | 可输入（激活弹窗，中文 IME 正常）  |
| 输入关键词         | 需点按钮/回车才过滤 | 边输入边过滤（停顿 200ms 后查询） |
| 清空搜索框         | 需手动触发      | 自动恢复全量列表             |
| 多选操作条         | 无全选        | 全选/取消全选（主窗口 + 弹窗）    |
| 关闭弹窗重开        | 搜索词残留      | 搜索词清空                |
| 光标在搜索栏按 Win+V | 闪一下消失      | 重新定位，搜索词保留           |
| 点条目粘贴         | 正常         | 正常（不激活，行为不变）         |
| 搜索期间原应用（如微信）  | —          | 短暂失焦、选区被清（主动场景，可接受）  |

## 验证

- `dart analyze`：0 error 0 warning
- 已构建实测（Windows Release）：搜索框中文输入（IME 候选框）、实时过滤、清空恢复、全选/取消全选（含全选后合并复制顺序）、关闭重开搜索词清空、重新定位不闪不消失、粘贴不受影响、点击外部关闭不受影响

## 已知限制

- 搜索期间弹窗被激活，原应用（如微信）选区会被清空——Windows 平台"不激活+完整输入"无解，主动搜索场景下可接受的权衡。
